### PR TITLE
feat: Add GitLab CI/CD pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,77 @@
+# Use an official Rust image.
+# See https://hub.docker.com/_/rust for available tags.
+image: rust:1.76 # Using a recent stable version
+
+variables:
+  CARGO_TERM_COLOR: "always"
+  # Assuming the binary name is 'gitbot' based on Cargo.toml package name
+  # This should be consistent with the GITHUB_ENV in the GitHub Action
+  BINARY_NAME: "gitbot" 
+
+stages:
+  - build_test
+  - release
+
+build_and_test_job:
+  stage: build_test
+  # Install clippy and rustfmt, as they might not be in all rust images by default
+  # or to ensure specific versions if needed, though dtolnay/rust-toolchain handles this in GH.
+  # For simplicity, we'll assume the base rust:1.76 image has recent enough versions or install them.
+  before_script:
+    - rustup component add clippy || true # Allow failure if already installed
+    - rustup component add rustfmt || true # Allow failure if already installed
+  script:
+    - cargo build --verbose
+    - cargo fmt -- --check
+    - cargo clippy -- -D warnings # Fail on any warnings
+    - cargo test --verbose
+  cache:
+    key:
+      files:
+        - Cargo.lock
+    paths:
+      - target/
+      - /usr/local/cargo/registry/ # Path for cargo registry in official rust docker images
+      - /usr/local/cargo/git/ # Path for cargo git sources in official rust docker images
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "main"'
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME == "main"'
+    - if: '$CI_COMMIT_TAG =~ /^v.*/' # Run for tags starting with 'v'
+
+release_job:
+  stage: release
+  # The 'image: rust:1.76' is defined globally.
+  # before_script for release might not be strictly necessary if build_and_test_job ensures tools.
+  script:
+    - cargo build --release --verbose
+    # Determine Asset Name and Path (GitLab CI variables are used here)
+    # CI_COMMIT_TAG is the tag name, e.g., v1.0.0
+    # BINARY_NAME is from the global variables
+    - |
+      TAG_NAME="$CI_COMMIT_TAG"
+      CLEAN_BINARY_NAME=$(echo "$BINARY_NAME" | tr -cd '[:alnum:]._-')
+      ASSET_NAME="${CLEAN_BINARY_NAME}-${TAG_NAME}-linux-amd64.tar.gz" 
+      # Assuming Linux AMD64 from the rust docker image, adjust if cross-compiling for other targets.
+      # The GitHub Action uses runner.os, which is ubuntu.
+      echo "ASSET_NAME=${ASSET_NAME}"
+      echo "RELEASE_TAG=${TAG_NAME}"
+      # Package the release binary
+      tar -czvf "${ASSET_NAME}" -C target/release "${BINARY_NAME}"
+    # Create GitLab Release using release-cli
+    # The release-cli is usually pre-installed on GitLab runners or can be downloaded.
+    # For simplicity, we assume it's available.
+    - release-cli create --name "Release ${CI_COMMIT_TAG}" --tag-name "${CI_COMMIT_TAG}"       --description "Release of ${BINARY_NAME} version ${CI_COMMIT_TAG}. See CHANGELOG.md for details (if available)."       --assets-link "{\"name\":\"$(echo $ASSET_NAME)\",\"url\":\"./$(echo $ASSET_NAME)\"}"
+  cache:
+    key:
+      files:
+        - Cargo.lock
+    paths:
+      - target/ # Specifically target/release will be populated
+      - /usr/local/cargo/registry/
+      - /usr/local/cargo/git/
+    policy: pull # For release, only pull, don't push cache
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^v.*/' # Only run for tags starting with 'v'
+  needs:
+    - job: build_and_test_job
+      artifacts: false # Doesn't need artifacts from build_and_test_job, will rebuild in release mode


### PR DESCRIPTION
This commit introduces a `.gitlab-ci.yml` file to set up a CI/CD pipeline for GitLab. The pipeline is designed to mirror the existing GitHub Actions workflow.

It includes two main jobs:

1.  `build_and_test_job`:
    *   Triggered on pushes to `main`, merge requests to `main`, and version tags.
    *   Builds the Rust project.
    *   Checks code formatting using `rustfmt`.
    *   Lints the code using `clippy`.
    *   Runs automated tests using `cargo test`.
    *   Caches Cargo dependencies to speed up subsequent runs.

2.  `release_job`:
    *   Triggered only on version tags (e.g., `v1.0.0`).
    *   Depends on the successful completion of `build_and_test_job`.
    *   Builds the Rust project in release mode.
    *   Packages the release binary into a `.tar.gz` archive.
    *   Creates a GitLab Release and uploads the packaged binary as an asset
        using GitLab's `release-cli`.

The pipeline uses an official Rust Docker image and defines variables consistent with the GitHub Actions setup.