### PR TITLE
Convert configuration from .env to clap-based CLI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,22 @@
+# Environment variables for gitbot
+# These can also be provided as command-line arguments
+# Run `./gitbot --help` for more information
+
+# GitLab configuration
 APP_GITLAB_URL="https://gitlab.com"
 APP_GITLAB_TOKEN="your_gitlab_token"
+
+# OpenAI configuration
 APP_OPENAI_API_KEY="your_openai_key"
-APP_OPENAI_CUSTOM_URL="your_openai_url"
-APP_OPENAI_MODEL="gpt-3.5-turbo" # The OpenAI model to use for chat completions
-APP_OPENAI_TEMPERATURE="0.7" # The temperature parameter for OpenAI API (0.0 to 1.0)
-APP_OPENAI_MAX_TOKENS="1024" # The maximum number of tokens to generate in the response
+APP_OPENAI_CUSTOM_URL="https://api.openai.com/v1"
+APP_OPENAI_MODEL="gpt-3.5-turbo"
+APP_OPENAI_TEMPERATURE="0.7"
+APP_OPENAI_MAX_TOKENS="1024"
+
+# Bot configuration
+APP_BOT_USERNAME="your_bot_username"
+APP_REPOS_TO_POLL="group1/project1,group2/project2"
+APP_POLL_INTERVAL_SECONDS="60"
 APP_LOG_LEVEL="info"
-APP_BOT_USERNAME="your_bot_username" # The username of the bot on GitLab (without @)
-APP_REPOS_TO_POLL="group1/project1,group2/project2" # Comma-separated list of repositories to poll
-APP_POLL_INTERVAL_SECONDS="60" # How often to poll for new mentions (in seconds)
-APP_CONTEXT_REPO_PATH="group/context-repo" # Optional repository to use for additional context when responding to issues
+APP_STALE_ISSUE_DAYS="30"
+APP_CONTEXT_REPO_PATH="group/context-repo"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,12 +232,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
 name = "colored"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -273,12 +369,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 
 [[package]]
-name = "dotenvy"
-version = "0.15.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,7 +390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -424,8 +514,8 @@ dependencies = [
  "anyhow",
  "base64 0.13.1",
  "chrono",
+ "clap",
  "config",
- "dotenvy",
  "hex",
  "hmac",
  "mockito",
@@ -493,6 +583,12 @@ name = "hashbrown"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -797,6 +893,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,6 +1102,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "openssl"
@@ -1360,7 +1468,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1530,6 +1638,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1594,7 +1708,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1830,6 +1944,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "gitbot"
 version = "0.1.0"
 edition = "2021"
+description = "A GitLab bot that responds to mentions using AI"
 
 [dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
@@ -9,7 +10,7 @@ reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 config = { version = "0.13", features = ["toml"] }
-dotenvy = "0.15"
+clap = { version = "4.5.38", features = ["derive", "env"] }
 anyhow = "1"
 thiserror = "1"
 tracing = "0.1"

--- a/README.md
+++ b/README.md
@@ -31,9 +31,23 @@ Ultimate licensing.
 
 To run the bot:
 ```bash
-./target/debug/gitbot
+./target/debug/gitbot --gitlab-token YOUR_GITLAB_TOKEN --openai-api-key YOUR_OPENAI_KEY --bot-username YOUR_BOT_USERNAME --repos-to-poll group/project1,group/project2
 # or for release
-./target/release/gitbot
+./target/release/gitbot --gitlab-token YOUR_GITLAB_TOKEN --openai-api-key YOUR_OPENAI_KEY --bot-username YOUR_BOT_USERNAME --repos-to-poll group/project1,group/project2
+```
+
+For a full list of available options:
+```bash
+./target/debug/gitbot --help
+```
+
+You can also set configuration via environment variables:
+```bash
+export APP_GITLAB_TOKEN=YOUR_GITLAB_TOKEN
+export APP_OPENAI_API_KEY=YOUR_OPENAI_KEY
+export APP_BOT_USERNAME=YOUR_BOT_USERNAME
+export APP_REPOS_TO_POLL=group/project1,group/project2
+./target/debug/gitbot
 ```
 
 ## Features

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,40 +1,78 @@
-use serde::Deserialize;
+use clap::Parser;
 use std::fmt::Debug;
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Clone, Parser)]
+#[command(
+    author,
+    version,
+    about = "A GitLab bot that responds to mentions using AI"
+)]
 pub struct AppSettings {
+    /// GitLab instance URL
+    #[arg(long, env = "APP_GITLAB_URL", default_value = "https://gitlab.com")]
     pub gitlab_url: String,
+
+    /// GitLab API token
+    #[arg(long, env = "APP_GITLAB_TOKEN")]
     pub gitlab_token: String,
+
+    /// OpenAI API key
+    #[arg(long, env = "APP_OPENAI_API_KEY")]
     pub openai_api_key: String,
+
+    /// Custom OpenAI API URL (if using a proxy or alternative endpoint)
+    #[arg(
+        long,
+        env = "APP_OPENAI_CUSTOM_URL",
+        default_value = "https://api.openai.com/v1"
+    )]
     pub openai_custom_url: String,
+
+    /// OpenAI model to use
+    #[arg(long, env = "APP_OPENAI_MODEL", default_value = "gpt-3.5-turbo")]
     pub openai_model: String,
+
+    /// Temperature parameter for OpenAI API (0.0 to 1.0)
+    #[arg(long, env = "APP_OPENAI_TEMPERATURE", default_value_t = 0.7)]
     pub openai_temperature: f32,
+
+    /// Maximum number of tokens to generate in the response
+    #[arg(long, env = "APP_OPENAI_MAX_TOKENS", default_value_t = 1024)]
     pub openai_max_tokens: u32,
-    #[serde(deserialize_with = "deserialize_repos_list")]
+
+    /// Comma-separated list of repositories to poll (format: group/project)
+    #[arg(long, env = "APP_REPOS_TO_POLL", value_parser = parse_repos_list)]
     pub repos_to_poll: Vec<String>,
+
+    /// Log level (trace, debug, info, warn, error)
+    #[arg(long, env = "APP_LOG_LEVEL", default_value = "info")]
     pub log_level: String,
+
+    /// Bot username on GitLab (without @)
+    #[arg(long, env = "APP_BOT_USERNAME")]
     pub bot_username: String,
+
+    /// How often to poll for new mentions (in seconds)
+    #[arg(long, env = "APP_POLL_INTERVAL_SECONDS", default_value_t = 60)]
     pub poll_interval_seconds: u64,
+
+    /// Number of days after which an issue is considered stale
+    #[arg(long, env = "APP_STALE_ISSUE_DAYS", default_value_t = 30)]
     pub stale_issue_days: u64,
-    pub context_repo_path: Option<String>, // Optional repository to use for additional context
+
+    /// Optional repository to use for additional context (format: group/project)
+    #[arg(long, env = "APP_CONTEXT_REPO_PATH")]
+    pub context_repo_path: Option<String>,
 }
 
-fn deserialize_repos_list<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let s = String::deserialize(deserializer)?;
+fn parse_repos_list(s: &str) -> Result<Vec<String>, String> {
     Ok(s.split(',').map(|item| item.trim().to_string()).collect())
 }
 
-pub fn load_config() -> Result<AppSettings, config::ConfigError> {
-    dotenvy::dotenv().ok();
-
-    let config = config::Config::builder()
-        .add_source(config::Environment::default().prefix("APP").separator("_"))
-        .build()?;
-
-    config.try_deserialize::<AppSettings>()
+pub fn load_config() -> anyhow::Result<AppSettings> {
+    // Parse command line arguments and environment variables
+    let app_settings = AppSettings::parse();
+    Ok(app_settings)
 }
 
 #[cfg(test)]
@@ -42,9 +80,22 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_parse_repos_list() {
+        let input = "group1/project1,group2/project2, group3/project3";
+        let result = parse_repos_list(input).unwrap();
+        assert_eq!(
+            result,
+            vec![
+                "group1/project1".to_string(),
+                "group2/project2".to_string(),
+                "group3/project3".to_string()
+            ]
+        );
+    }
+
+    #[test]
     fn test_create_app_settings() {
-        // Instead of testing load_config which depends on environment variables,
-        // let's test that we can create an AppSettings struct directly
+        // Create AppSettings directly for testing
         let settings = AppSettings {
             gitlab_url: "https://gitlab.example.com".to_string(),
             gitlab_token: "test_gitlab_token".to_string(),

--- a/src/repo_context.rs
+++ b/src/repo_context.rs
@@ -335,7 +335,7 @@ mod tests {
             log_level: "debug".to_string(),
             bot_username: "gitbot".to_string(),
             poll_interval_seconds: 60,
-            stale_issue_days: 30, // Added default for tests
+            stale_issue_days: 30,
             context_repo_path: None,
         };
 


### PR DESCRIPTION
## Description
This PR converts the application configuration from using .env files to a clap-based CLI approach. Environment variables are still supported through clap's env attribute.

## Changes
- Added clap dependency with derive and env features
- Converted AppSettings struct to use clap::Parser
- Updated configuration loading to use command-line arguments
- Modified environment variable handling to work with clap
- Updated README.md with new CLI usage instructions
- Updated .env.example with new format and comments
- Fixed tests to work with new AppSettings structure

## Testing
- All tests pass with cargo test
- No clippy warnings with cargo clippy
- Code formatted with cargo fmt

## Documentation
- Updated README.md with new CLI usage instructions
- Updated .env.example with new format and comments