### PR TITLE
Refactor openai url handling

### DIFF
--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -718,7 +718,10 @@ mod tests {
         let _m = server
             .mock("GET", "/api/v4/projects/1/issues")
             .match_query(mockito::Matcher::AllOf(vec![
-                mockito::Matcher::UrlEncoded("updated_after".into(), "1620000000".into()),
+                mockito::Matcher::UrlEncoded(
+                    "updated_after".into(),
+                    "2021-05-03T00:00:00+00:00".into(),
+                ),
                 mockito::Matcher::UrlEncoded("sort".into(), "asc".into()),
                 mockito::Matcher::UrlEncoded("per_page".into(), "100".into()),
             ]))
@@ -763,7 +766,10 @@ mod tests {
         let _m = server
             .mock("GET", "/api/v4/projects/1/merge_requests")
             .match_query(mockito::Matcher::AllOf(vec![
-                mockito::Matcher::UrlEncoded("updated_after".into(), "1620000000".into()),
+                mockito::Matcher::UrlEncoded(
+                    "updated_after".into(),
+                    "2021-05-03T00:00:00+00:00".into(),
+                ),
                 mockito::Matcher::UrlEncoded("sort".into(), "asc".into()),
                 mockito::Matcher::UrlEncoded("per_page".into(), "100".into()),
             ]))
@@ -816,7 +822,10 @@ mod tests {
         let _m = server
             .mock("GET", "/api/v4/projects/1/issues/101/notes")
             .match_query(mockito::Matcher::AllOf(vec![
-                mockito::Matcher::UrlEncoded("created_after".into(), "1620000000".into()),
+                mockito::Matcher::UrlEncoded(
+                    "created_after".into(),
+                    "2021-05-03T00:00:00+00:00".into(),
+                ),
                 mockito::Matcher::UrlEncoded("sort".into(), "asc".into()),
                 mockito::Matcher::UrlEncoded("per_page".into(), "100".into()),
             ]))
@@ -869,7 +878,10 @@ mod tests {
         let _m = server
             .mock("GET", "/api/v4/projects/1/merge_requests/5/notes")
             .match_query(mockito::Matcher::AllOf(vec![
-                mockito::Matcher::UrlEncoded("created_after".into(), "1620000000".into()),
+                mockito::Matcher::UrlEncoded(
+                    "created_after".into(),
+                    "2021-05-03T00:00:00+00:00".into(),
+                ),
                 mockito::Matcher::UrlEncoded("sort".into(), "asc".into()),
                 mockito::Matcher::UrlEncoded("per_page".into(), "100".into()),
             ]))

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -570,13 +570,12 @@ mod tests {
                 "Hello @gitbot please help with this {}",
                 noteable_type.to_lowercase()
             ),
-            author_id: 1,
             author: user.clone(),
             project_id: 1,
             noteable_type: noteable_type.to_string(),
             noteable_id: Some(1),
             iid: Some(1),
-            url: "https://gitlab.example.com/org/repo1/-/issues/1#note_1".to_string(),
+            url: Some("https://gitlab.example.com/org/repo1/-/issues/1#note_1".to_string()),
             updated_at: "2023-01-01T00:00:00Z".to_string(), // Added default for tests
         };
 

--- a/src/polling.rs
+++ b/src/polling.rs
@@ -531,7 +531,7 @@ mod tests {
             noteable_type: "Issue".to_string(),
             noteable_id: Some(1), // Assuming it's for issue iid 1, adjust if needed per test
             iid: Some(1),         // Assuming it's for issue iid 1
-            url: format!("http://example.com/notes/{}", id),
+            url: Some(format!("http://example.com/notes/{}", id)),
             updated_at: updated_at_str.to_string(),
         }
     }


### PR DESCRIPTION
Refactor OpenAI URL handling and update Rust environment
This commit addresses the issue of incorrect OpenAI URL construction.
The `OpenAIApiClient` now correctly treats the `openai_custom_url` as a base URL and appends the specific path for chat completions (i.e., `/chat/completions`).

Changes include:
- Updated `src/openai.rs` to modify URL joining logic in `send_chat_completion`.
- Adjusted tests in `src/openai.rs` to reflect the new URL handling, ensuring mock HTTP calls use the correct base and appended paths.
- Updated Rust to the latest stable version and installed `rustfmt` and `clippy`.
- Ran `cargo clippy --fix` to resolve linting issues.
- Ran `cargo fmt` to ensure consistent code formatting.