### PR TITLE
Update dependency versions in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,18 +10,18 @@ reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 config = { version = "0.13", features = ["toml"] }
-clap = { version = "4.5.38", features = ["derive", "env"] }
+clap = { version = "4.5", features = ["derive", "env"] }
 anyhow = "1"
 thiserror = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
-url = "2.3"
+url = "2.5"
 hmac = "0.12"
 sha2 = "0.10"
 hex = "0.4"
 urlencoding = "2.1"
 base64 = "0.13"
-chrono = { version = "0.4.41", features = ["serde"] }
+chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
 mockito = "1"


### PR DESCRIPTION
This PR updates dependency versions in Cargo.toml to use more flexible version specifications:

- Update url from 2.3 to 2.5
- Update clap from 4.5.38 to 4.5
- Update chrono from 0.4.41 to 0.4

All tests pass, clippy shows no warnings, and code formatting is maintained.

Closes #35

@myaple can click here to [continue refining the PR](https://app.all-hands.dev/conversations/{})