### PR TITLE
feat: Introduce structured LLM output for slash commands

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -146,3 +146,60 @@ pub struct GitlabCommit {
     pub committed_date: String,
     pub message: String,
 }
+
+// Structured output for /summarize command
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SummarizeOutput {
+    pub adherence_to_guidelines: String,
+    pub performance_impact: String,
+    pub strengths: String,
+    pub areas_for_improvement: String,
+    pub conclusion_and_recommendations: String,
+}
+
+// Structured output for /postmortem command
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct PostmortemOutput {
+    pub timeline: String,
+    pub root_cause_analysis: String,
+}
+
+// Structured output for /suggestions command
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SuggestionsOutput {
+    pub suggested_solution: String,
+}
+
+// Description of a single command for /help
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CommandDescription {
+    pub name: String,
+    pub description: String,
+}
+
+// Structured output for /help command
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct HelpOutput {
+    pub available_commands: Vec<CommandDescription>,
+    pub usage_instructions: String,
+}
+
+// Enum to wrap all possible structured output types
+// This will be useful for the return type of functions that parse the LLM response.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(untagged)] // Allows deserializing into the first matching variant
+pub enum StructuredLlMResponse {
+    Summary(SummarizeOutput),
+    Postmortem(PostmortemOutput),
+    Suggestions(SuggestionsOutput),
+    Help(HelpOutput),
+    // Potentially add a variant for plain text fallback if needed
+    // PlainText(String),
+}
+
+// Enum to represent either a structured response or a plain text string from the LLM
+#[derive(Debug, Clone)]
+pub enum LLMResponse {
+    Structured(StructuredLlMResponse),
+    Plain(String),
+}

--- a/src/tests/handlers_tests.rs
+++ b/src/tests/handlers_tests.rs
@@ -986,7 +986,7 @@ mod tests {
                         "index": 0,
                         "message": {
                             "role": "assistant",
-                            "content": "Security analysis summary with guidelines adherence."
+                            "content": "{\n  \"adherence_to_guidelines\": \"The MR largely adheres to the contribution guidelines.\",\n  \"performance_impact\": \"No significant performance impact is expected.\",\n  \"strengths\": \"The code is well-structured and includes good test coverage.\",\n  \"areas_for_improvement\": \"Consider adding more detailed comments in complex sections.\",\n  \"conclusion_and_recommendations\": \"Overall, this is a good MR. Recommend merging after addressing minor comments.\"\n}"
                         },
                         "finish_reason": "stop"
                     }],
@@ -1164,7 +1164,7 @@ mod tests {
                         "index": 0,
                         "message": {
                             "role": "assistant",
-                            "content": "Here are the available commands..."
+                            "content": "{\n  \"available_commands\": [\n    {\n      \"name\": \"/summarize\",\n      \"description\": \"Generates a summary of the changes in an MR or the content of an issue.\"\n    },\n    {\n      \"name\": \"/help\",\n      \"description\": \"Displays this help message with available commands.\"\n    }\n  ],\n  \"usage_instructions\": \"Mention @test_bot with a command. For example: @test_bot /summarize\"\n}"
                         },
                         "finish_reason": "stop"
                     }],


### PR DESCRIPTION

This change implements structured output handling for GitBot's slash commands.

- Defines Rust structs for the expected JSON output of /summarize, /postmortem, /suggestions, and /help commands.
- Modifies prompts for these slash commands to explicitly request JSON output conforming to the defined schemas.
- Updates OpenAI response handling to parse the JSON content into these structs.
- Implements new reply formatting logic to generate Markdown from the structured data, creating distinct sections in the bot's comments.
- Default (non-slash command) interactions continue to use plain text prompts and responses to maintain flexibility.
- Includes error handling for JSON deserialization failures.
- Updates integration tests to mock structured JSON responses for slash commands.

This will improve the consistency, quality, and extensibility of GitBot's responses to slash commands.