### PR TITLE
Refactor risky unwrap in polling.rs

### DIFF
--- a/src/polling.rs
+++ b/src/polling.rs
@@ -356,7 +356,13 @@ impl PollingService {
                 let project = project.clone();
                 let mention_count = mention_count.clone();
                 async move {
-                    let note_data = event.note.unwrap(); // safe: pre-filtered above
+                    let note_data = match event.note {
+                        Some(note) => note,
+                        None => {
+                            error!("Unexpected missing note in pre-filtered event for project {}", project.id);
+                            return;
+                        }
+                    };
 
                     let noteable_iid = note_data.noteable_iid.unwrap_or(0);
                     let noteable_id = note_data.noteable_id.unwrap_or(0);

--- a/src/polling.rs
+++ b/src/polling.rs
@@ -359,7 +359,10 @@ impl PollingService {
                     let note_data = match event.note {
                         Some(note) => note,
                         None => {
-                            error!("Unexpected missing note in pre-filtered event for project {}", project.id);
+                            error!(
+                                "Unexpected missing note in pre-filtered event for project {}",
+                                project.id
+                            );
                             return;
                         }
                     };


### PR DESCRIPTION
Replaced `event.note.unwrap()` with a `match` statement in `src/polling.rs` to handle potential `None` values gracefully by logging an error and returning early, preventing runtime panics. Verified with regression tests.

---
*PR created automatically by Jules for task [4291548975554083862](https://jules.google.com/task/4291548975554083862) started by @myaple*